### PR TITLE
Implement LifecycleEventListener and stop listening on app pause/close

### DIFF
--- a/android/src/main/java/com/fingerprint/identify/RNFingerprintIdentifyModule.java
+++ b/android/src/main/java/com/fingerprint/identify/RNFingerprintIdentifyModule.java
@@ -70,7 +70,7 @@ public class RNFingerprintIdentifyModule extends ReactContextBaseJavaModule impl
 
     mIsCalledStartIdentify = true;
     mFingerprintIdentify.resumeIdentify();
-    mFingerprintIdentify.startIdentify(6, new BaseFingerprint.FingerprintIdentifyListener() {
+    mFingerprintIdentify.startIdentify(5, new BaseFingerprint.FingerprintIdentifyListener() {
       @Override
       public void onSucceed() {
         // succeed, release hardware automatically

--- a/android/src/main/java/com/fingerprint/identify/RNFingerprintIdentifyModule.java
+++ b/android/src/main/java/com/fingerprint/identify/RNFingerprintIdentifyModule.java
@@ -2,6 +2,7 @@
 package com.fingerprint.identify;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -17,7 +18,7 @@ import android.content.Context;
 import android.app.Activity;
 import android.util.Log;
 
-public class RNFingerprintIdentifyModule extends ReactContextBaseJavaModule {
+public class RNFingerprintIdentifyModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
   private final ReactApplicationContext reactContext;
   private FingerprintIdentify mFingerprintIdentify = null;
@@ -28,6 +29,7 @@ public class RNFingerprintIdentifyModule extends ReactContextBaseJavaModule {
   public RNFingerprintIdentifyModule(ReactApplicationContext reactContext) {
     super(reactContext);
     this.reactContext = reactContext;
+    reactContext.addLifecycleEventListener(this);
   }
 
   @Override
@@ -144,5 +146,23 @@ public class RNFingerprintIdentifyModule extends ReactContextBaseJavaModule {
        response.putString("status", status);
        response.putString("error", message);
        promise.resolve(response);
+
+  }
+  
+  @Override
+  public void onHostResume() {
+    if (mIsCalledStartIdentify) {
+      mFingerprintIdentify.resumeIdentify();
+    }
+  }
+
+  @Override
+  public void onHostPause() {
+    mFingerprintIdentify.cancelIdentify();
+  }
+
+  @Override
+  public void onHostDestroy() {
+    mFingerprintIdentify.cancelIdentify();
   }
 }


### PR DESCRIPTION
Currently the app still listens to fingerprint when the app is in the background which is undesired behaviour and I can't think of a reason why we would not want to handle it at library level.